### PR TITLE
Use select_slo_counts instead of querying counters individually

### DIFF
--- a/slo2bq/clients/sd_slo_client.go
+++ b/slo2bq/clients/sd_slo_client.go
@@ -64,7 +64,6 @@ type servicesResponse struct {
 type SLO struct {
 	Name        string  `json:"name"`
 	DisplayName string  `json:"displayName"`
-	SLI         *SLI    `json:"serviceLevelIndicator"`
 	Goal        float64 `json:"goal"`
 }
 
@@ -76,24 +75,6 @@ func (s *SLO) HumanName() string {
 	// Name is like 'projects/$project/services/$service/serviceLevelObjectives/$slo'.
 	elements := strings.Split(s.Name, "/")
 	return elements[5]
-}
-
-// SLI is a Service Level Indicator.
-type SLI struct {
-	RequestBasedSLI *RequestBasedSLI `json:"requestBased"`
-	// NOTE: other types of SLIs are not implemented by this client yet.
-}
-
-// RequestBasedSLI is an SLI based on a request counter.
-type RequestBasedSLI struct {
-	GoodTotalRatioSLI *GoodTotalRatioSLI `json:"goodTotalRatio"`
-}
-
-// GoodTotalRatioSLI is an SLI based on counters of good & bad requests.
-type GoodTotalRatioSLI struct {
-	Good  string `json:"goodServiceFilter"`
-	Bad   string `json:"badServiceFilter"`
-	Total string `json:"totalServiceFilter"`
 }
 
 type slosResponse struct {

--- a/slo2bq/function.go
+++ b/slo2bq/function.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"log"
 	"slo2bq/clients"
+	"time"
 
 	"golang.org/x/oauth2/google"
-	"time"
 )
 
 // BigQuery table name for the raw data.


### PR DESCRIPTION
This also means `sd_slo_client` no longer has to know about different kinds of SLIs, so I've simplified it a bit, removing struct fields that are no longer necessary.